### PR TITLE
Bower.json requires ignore section

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,6 @@
   "name": "angular-numeraljs",
   "version": "0.1.0",
   "main": ["./src/angular-numeraljs.js"],
-  "ignore": ["bower.json"],
+  "ignore": [],
   "dependencies": {}
 } 


### PR DESCRIPTION
Bower install is popping up a warning because there is no ignore section in the manifest. Please add this missing section to reduce the noise in our build.
