### PR TITLE
Update bower.json with empty ignore

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,5 +2,6 @@
   "name": "angular-numeraljs",
   "version": "0.1.0",
   "main": ["./src/angular-numeraljs.js"],
-  "dependencies": {}
+  "dependencies": {},
+  "ignore":{}
 } 


### PR DESCRIPTION
avoid 'invalid-meta angular-bootstrap-affix is missing "ignore" entry in bower.json' when installing via bower. As suggested here: bower/bower#1388
